### PR TITLE
Update neural_style.py

### DIFF
--- a/neural_style.py
+++ b/neural_style.py
@@ -555,7 +555,7 @@ def check_image(img, path):
   rendering -- where the magic happens
 '''
 def stylize(content_img, style_imgs, init_img, frame=None):
-  with tf.device(args.device), tf.Session() as sess:
+  with tf.device(args.device), tf.compat.v1.Session() as sess:
     # setup network
     net = build_model(content_img)
     


### PR DESCRIPTION
saw following warning when running the neural-style-tf notebook: 

```WARNING:tensorflow:From neural_style.py:558: The name tf.Session is deprecated. Please use tf.compat.v1.Session instead.```